### PR TITLE
hide download text on smaller screens

### DIFF
--- a/src/components/Song.vue
+++ b/src/components/Song.vue
@@ -25,7 +25,7 @@
           target="_blank"
           :href="song.link"
           class="rounded-full flex items-center gap-2 border-2 border-accent select-none bg-accent h-min text-white px-4 py-2"
-          ><i-fluency-save /> Download</a
+          ><i-fluency-save /><span class="hidden sm:block">Download</span></a
         >
       </div>
     </div>


### PR DESCRIPTION
Noticed on my iPhone that the downloads page could use a change. Per Blusk's suggestion, the download text disappears on small screen sizes.

**What is used to look like:**

> ![image](https://user-images.githubusercontent.com/96668453/147400565-8bd4a01f-0b70-4d4c-81a8-a7f9f240f933.png)

**What it looks like now:**

> ![image](https://user-images.githubusercontent.com/96668453/147400517-334663c5-c480-4886-b583-b8e552723ef3.png)
