### PR TITLE
fixed size of covers for mobile and desktop

### DIFF
--- a/src/components/Cover.vue
+++ b/src/components/Cover.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cursor-pointer box-content cover overflow-hidden rounded-4px relative w-full h-full">
+  <div class="cursor-pointer box-content cover rounded-4px relative w-full">
     <div class="flex gap-2 bg-white text-text">
       <a v-if="cover" target="_blank " :href="cover.original">
         <img class="w-full h-full" :src="preview" :alt="cover.name" />


### PR DESCRIPTION
Fixed the size of covers for desktop and mobile.

Before:

> ![iphone before](https://user-images.githubusercontent.com/96668453/147424803-1fae3944-5b12-466e-b220-dc98fc273ae6.png)
> 
> ![desktop before](https://user-images.githubusercontent.com/96668453/147424811-23c6bd95-b51b-4d71-9940-7380eae92e6e.png)
> 
> 
> 

After:

> ![iphone after](https://user-images.githubusercontent.com/96668453/147424816-0e46a917-c27a-4d83-b847-92dbf259baf5.png)
> 
> ![desktop after](https://user-images.githubusercontent.com/96668453/147424819-470a92d4-bbb0-4557-8d34-e4d15e707e73.png)

