### PR TITLE
a few fixups

### DIFF
--- a/src/components/Song.vue
+++ b/src/components/Song.vue
@@ -2,7 +2,7 @@
   <div class="hover:bg-theme-300 rounded-4px overflow-hidden flex flex-col w-full">
     <div class="flex justify-between items-center">
       <div class="flex items-center gap-4">
-        <div class="w-24 min-w-24">
+        <div class="w-24 min-w-24 h-24 min-h-24">
           <Cover :cover="cover" />
         </div>
         <div class="flex flex-col w-auto md:w-64">

--- a/src/views/Downloads.vue
+++ b/src/views/Downloads.vue
@@ -12,7 +12,7 @@
 
     <div v-if="activeRoute == 'songs'" class="flex flex-col gap-2 w-full">
       <input
-        class="rounded-4px p-2 border-2 border-transparent bg-theme-300 focus:border-accent"
+        class="rounded-4px p-2 border-2 border-transparent bg-theme-300 focus:border-accent text-title"
         v-model="coverSearch"
         type="text"
         placeholder="Search for a song..."


### PR DESCRIPTION
Before, loading album arts will make the cards look weird:
![image](https://github.com/Geoxor/geoxor.moe/assets/52386117/edfb97c0-6d01-41d7-adfb-a38c7753bb1f)
Now they don't layout shift:
![image](https://github.com/Geoxor/geoxor.moe/assets/52386117/e0c77f04-f1a7-4d86-ba7d-f0e470e49874)

Also now input text is colored properly to look good in dark mode:
![image](https://github.com/Geoxor/geoxor.moe/assets/52386117/c91a9a84-5347-496f-87c9-ab9df7229363)
